### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/io-storage.cabal
+++ b/io-storage.cabal
@@ -19,7 +19,7 @@ license:       BSD3
 license-file:  LICENSE
 
 build-type:    Simple
-cabal-version: >= 1.6
+cabal-version: >= 1.8
 
 library
   exposed-modules: System.IO.Storage


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: io-storage.cabal:26:32: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```